### PR TITLE
Add github workflow to build jar file

### DIFF
--- a/.github/workflows/release-keycloak-scim.yaml
+++ b/.github/workflows/release-keycloak-scim.yaml
@@ -1,0 +1,34 @@
+name: Build keycloak-scim and release
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Build with Gradle
+      run: gradle build --rerun-tasks clean
+
+    - name: Create Release with jar file
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: false
+        title: "keycloak-scim release"
+        files: |
+          ./build-libs/*.jar


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/ol-infrastructure/issues/1799
# Description (What does it do?)
<!--- Describe your changes in detail -->
Added a GitHub workflow that would run a gradle build whenever there's a commit to the main branch which would allow us to add this plugin to our existing keycloak build pipeline.

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I ran a gradle build locally with the patched forked version and it generated the JAR file which I tested on a Keycloak instance and it was successful.