### PR TITLE
Populates first and late name, user created after email verification

### DIFF
--- a/src/main/java/sh/libre/scim/core/UserAdapter.java
+++ b/src/main/java/sh/libre/scim/core/UserAdapter.java
@@ -27,6 +27,8 @@ public class UserAdapter extends Adapter<UserModel, User> {
 
     private String username;
     private String displayName;
+    private String givenName;
+    private String familyName;
     private String email;
     private Boolean active;
     private String[] roles;
@@ -43,6 +45,22 @@ public class UserAdapter extends Adapter<UserModel, User> {
         if (this.username == null) {
             this.username = username;
         }
+    }
+
+    public String getGivenName() {
+        return givenName;
+    }
+
+    public void setGivenName(String givenName) {
+        this.givenName = givenName;
+    }
+
+    public String getFamilyName() {
+        return familyName;
+    }
+
+    public void setFamilyName(String familyName) {
+        this.familyName = familyName;
     }
 
     public String getDisplayName() {
@@ -92,6 +110,8 @@ public class UserAdapter extends Adapter<UserModel, User> {
     public void apply(UserModel user) {
         setId(user.getId());
         setUsername(user.getUsername());
+        setGivenName(user.getFirstName());
+        setFamilyName(user.getLastName());
         var displayName = String.format("%s %s", StringUtils.defaultString(user.getFirstName()),
                 StringUtils.defaultString(user.getLastName())).trim();
         if (StringUtils.isEmpty(displayName)) {
@@ -138,6 +158,8 @@ public class UserAdapter extends Adapter<UserModel, User> {
         user.setId(externalId);
         user.setDisplayName(displayName);
         Name name = new Name();
+        name.setGivenName(givenName);
+        name.setFamilyName(familyName);
         user.setName(name);
         var emails = new ArrayList<Email>();
         if (email != null) {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/keycloak-scim/issues/39

### Description (What does it do?)

1. Maps Keycloak user's first and last name to the correct attributes in the SCIM extension.  This ensures that all SCIM requests for creating users will include the first and last name.
2. Users are only provisioned via SCIM when they have verified their email address.

### How can this be tested?
**Setup**

1. Keycloak running locally.
3. This branch is built and the resulting jar file is placed within the "providers" folder in your keycloak instance. (instructions: https://docs.google.com/document/d/17tJ-C2EwWoSpJWZKjuhMVgsqGtyPH0IN9KakXvSKU0M/edit?pli=1#heading=h.k62uq36ldhsa)
4. MIT Open is running locally.  An admin user is created and an access token, like the one shown below, is created.
![Screenshot 2024-03-08 at 10 10 15 AM](https://github.com/mitodl/keycloak-scim/assets/8311573/1036a868-f84f-49af-bdf4-4e65de2fd470)
5. Your local instance of Keycloak is configured with the ol login theme, browser flow matching what is in QA as of this PRs creation date, SMTP email provider configured, and SCIM federation is configured to work with your local MIT Open instance, shown below.
![Screenshot 2024-03-08 at 10 12 07 AM](https://github.com/mitodl/keycloak-scim/assets/8311573/b1ce9ad6-61cd-4b46-9f4b-5ea09f3636bb)

**Test**

1. Follow the registration flow in Keycloak.
2. Before completing the email verification step, verify that no user has been provisioned in MIT Open via SCIM.
3. After completing the email verification step, verify that a user has been provisioned in MIT Open via SCIM.  Verify that the user has their first and last name populated.
