### PR TITLE
fix: format put/delete paths correctly

### DIFF
--- a/src/main/java/sh/libre/scim/core/ScimClient.java
+++ b/src/main/java/sh/libre/scim/core/ScimClient.java
@@ -97,7 +97,7 @@ public class ScimClient {
     }
 
     protected String genScimUrl(String scimEndpoint, String resourcePath) {
-        return "%s%s/%s".formatted(scimApplicationBaseUrl,
+        return "%s/%s/%s".formatted(scimApplicationBaseUrl,
                 scimEndpoint,
                 resourcePath);
     }


### PR DESCRIPTION
### What are the relevant tickets?
closes #132

### Description (What does it do?)
path should be `/scim/v2/Groups/<id>` rather than `/scim/v2Groups/<id>`
