### PR TITLE
Fix NullPointerException on every Admin-API user DELETE

### DIFF
--- a/src/main/java/sh/libre/scim/event/ScimEventListenerProvider.java
+++ b/src/main/java/sh/libre/scim/event/ScimEventListenerProvider.java
@@ -83,10 +83,7 @@ public class ScimEventListenerProvider implements EventListenerProvider {
                 }
             }
             if (event.getOperationType() == OperationType.DELETE) {
-                var user = getUser(userId);
-                if (user.isEmailVerified()) {
-                    dispatcher.run(ScimDispatcher.SCOPE_USER, client -> client.delete(UserAdapter.class, userId));
-                }
+                dispatcher.run(ScimDispatcher.SCOPE_USER, client -> client.delete(UserAdapter.class, userId));
             }
         }
         if (event.getResourceType() == ResourceType.GROUP) {


### PR DESCRIPTION
## Summary

Fixes #181. `ScimEventListenerProvider.onEvent(AdminEvent, boolean)`'s `DELETE` branch throws a `NullPointerException` on every single Admin-API user delete, so a DELETE never actually reaches the configured SCIM service provider.

## Root cause

```java
if (event.getOperationType() == OperationType.DELETE) {
    var user = getUser(userId);
    if (user.isEmailVerified()) {
        dispatcher.run(ScimDispatcher.SCOPE_USER, client -> client.delete(UserAdapter.class, userId));
    }
}
```

`getUser(userId)` calls `session.users().getUserById(...)`. By the time the `DELETE` admin event fires, Keycloak has already removed that user's row, so `getUser` always returns `null`, and the unchecked `user.isEmailVerified()` call throws unconditionally.

## Fix

Drop the `isEmailVerified()` gate for `DELETE` and dispatch unconditionally — matching how the self-service `EventType.DELETE_ACCOUNT` branch a few lines above in this same file already handles this, with no such gate:

```java
if (event.getType() == EventType.DELETE_ACCOUNT) {
    dispatcher.run(ScimDispatcher.SCOPE_USER, client -> client.delete(UserAdapter.class, event.getUserId()));
}
```

This is safe because `ScimClient.delete()` already has its own guard: it looks up the SCIM mapping for that user ID via a local JPA query, and no-ops (logs "scim mapping not found") if nothing was ever synced for it. The `isEmailVerified()` pre-check in the Admin-API `DELETE` branch wasn't protecting anything the mapping-table check doesn't already handle — it was just broken.

## Verification

Reproduced and verified against a real Keycloak 25.0.6 instance with this plugin built from source (`gradle jar shadowjar`), not mocked:

- **Unpatched**: every Admin-API user delete produces `KC-SERVICES0085: Failed to send type to ScimEventListenerProvider` / `NullPointerException: Cannot invoke "org.keycloak.models.UserModel.isEmailVerified()" because "user" is null` at `ScimEventListenerProvider.java:87`, and no DELETE ever reaches the configured SCIM endpoint.
- **Patched**: a full create → update → delete lifecycle against a live SCIM consumer correctly propagates all three operations.

This surfaced while building a conformance-testing harness for [scimitar](https://github.com/mario/scimitar), a Rust SCIM 2.0 library — happy to share the exact repro (Docker Compose Keycloak setup + integration test) if useful for review.
